### PR TITLE
feat: add class methods rules in recommended set

### DIFF
--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -10,5 +10,12 @@ import { imports } from '../rules/imports';
 export const recommended: ConfigArray = config(
     base,
     imports,
-    codeStyle
+    codeStyle,
+    {
+        rules: {
+            'class-methods-use-this': 'error',
+            '@typescript-eslint/explicit-member-accessibility': 'error',
+            '@typescript-eslint/explicit-function-return-type': 'error'
+        }
+    }
 );


### PR DESCRIPTION
Adds new rules:

- 'class-methods-use-this': 'error',
- '@typescript-eslint/explicit-member-accessibility': 'error',
- '@typescript-eslint/explicit-function-return-type': 'error'